### PR TITLE
fix: correct block number field in RpcBlock struct（fixes #36）

### DIFF
--- a/chain/ethereum/ethereum.go
+++ b/chain/ethereum/ethereum.go
@@ -195,6 +195,7 @@ func (c *ChainAdaptor) GetBlockByNumber(req *account.BlockNumberRequest) (*accou
 			Msg:  "block by number error",
 		}, nil
 	}
+	blockNumber, _ := block.NumberUint64()
 	var txListRet []*account.BlockInfoTransactionList
 	for _, v := range block.Transactions {
 		bitlItem := &account.BlockInfoTransactionList{
@@ -203,7 +204,7 @@ func (c *ChainAdaptor) GetBlockByNumber(req *account.BlockNumberRequest) (*accou
 			TokenAddress:   v.To,
 			ContractWallet: v.To,
 			Hash:           v.Hash,
-			Height:         block.Height,
+			Height:         blockNumber,
 			Amount:         v.Value,
 		}
 		txListRet = append(txListRet, bitlItem)
@@ -211,7 +212,7 @@ func (c *ChainAdaptor) GetBlockByNumber(req *account.BlockNumberRequest) (*accou
 	return &account.BlockResponse{
 		Code:         common2.ReturnCode_SUCCESS,
 		Msg:          "block by number success",
-		Height:       int64(block.Height),
+		Height:       int64(blockNumber),
 		Hash:         block.Hash.String(),
 		BaseFee:      block.BaseFee,
 		Transactions: txListRet,
@@ -237,10 +238,11 @@ func (c *ChainAdaptor) GetBlockByHash(req *account.BlockHashRequest) (*account.B
 		}
 		txListRet = append(txListRet, bitlItem)
 	}
+	blockNumber, _ := block.NumberUint64()
 	return &account.BlockResponse{
 		Code:         common2.ReturnCode_SUCCESS,
 		Msg:          "block by hash success",
-		Height:       int64(block.Height),
+		Height:       int64(blockNumber),
 		Hash:         block.Hash.String(),
 		BaseFee:      block.BaseFee,
 		Transactions: txListRet,

--- a/chain/evmbase/ethclient.go
+++ b/chain/evmbase/ethclient.go
@@ -35,9 +35,13 @@ type TransactionList struct {
 
 type RpcBlock struct {
 	Hash         common.Hash       `json:"hash"`
-	Height       uint64            `json:"height"`
+	Number       string            `json:"number"`
 	Transactions []TransactionList `json:"transactions"`
 	BaseFee      string            `json:"baseFeePerGas"`
+}
+
+func (b *RpcBlock) NumberUint64() (uint64, error) {
+	return hexutil.DecodeUint64(b.Number)
 }
 
 type clnt struct {

--- a/chain/polygon/polygon.go
+++ b/chain/polygon/polygon.go
@@ -207,6 +207,7 @@ func (c *ChainAdaptor) GetBlockByNumber(req *account.BlockNumberRequest) (*accou
 			Msg:  "block by number error",
 		}, nil
 	}
+	blockNumber, _ := block.NumberUint64()
 	var txListRet []*account.BlockInfoTransactionList
 	for _, v := range block.Transactions {
 		bitlItem := &account.BlockInfoTransactionList{
@@ -215,7 +216,7 @@ func (c *ChainAdaptor) GetBlockByNumber(req *account.BlockNumberRequest) (*accou
 			TokenAddress:   v.To,
 			ContractWallet: v.To,
 			Hash:           v.Hash,
-			Height:         block.Height,
+			Height:         blockNumber,
 			Amount:         v.Value,
 		}
 		txListRet = append(txListRet, bitlItem)
@@ -223,7 +224,7 @@ func (c *ChainAdaptor) GetBlockByNumber(req *account.BlockNumberRequest) (*accou
 	return &account.BlockResponse{
 		Code:         common2.ReturnCode_SUCCESS,
 		Msg:          "block by number success",
-		Height:       int64(block.Height),
+		Height:       int64(blockNumber),
 		Hash:         block.Hash.String(),
 		BaseFee:      block.BaseFee,
 		Transactions: txListRet,
@@ -249,10 +250,11 @@ func (c *ChainAdaptor) GetBlockByHash(req *account.BlockHashRequest) (*account.B
 		}
 		txListRet = append(txListRet, bitlItem)
 	}
+	blockNumber, _ := block.NumberUint64()
 	return &account.BlockResponse{
 		Code:         common2.ReturnCode_SUCCESS,
 		Msg:          "block by hash success",
-		Height:       int64(block.Height),
+		Height:       int64(blockNumber),
 		Hash:         block.Hash.String(),
 		BaseFee:      block.BaseFee,
 		Transactions: txListRet,


### PR DESCRIPTION
fix: correct block number field in RpcBlock struct (fixes #36)

This PR fixes #36.

**Changes**:
- Changed `Height` to `Number` in `RpcBlock` struct to align with Ethereum RPC spec
- Added helper method `NumberUint64()` for hex to uint64 conversion
- Updated related chain adapters for Ethereum and Polygon

**Testing**:
- Ran `TestChainAdaptor_GetBlockByNumber` to verify the fix
- Confirmed the response now contains the correct `number` field

**Before Fix**:
```json
{
  // Missing `height ` field due to incorrect field name in struct
}
```

**After Fix**:
```json
{
  "height": "0x14d380e"
}
```

**Related Issue**: #36